### PR TITLE
Add humorous message for invalid number input

### DIFF
--- a/src/calculator.py
+++ b/src/calculator.py
@@ -17,7 +17,7 @@ def read_number(prompt: str) -> float:
         try:
             return float(input(prompt).strip())
         except ValueError:
-            print('Please enter a valid number.')
+            print("That doesn't look like a number. Did your cat walk on the keyboard?")
 
 
 def main() -> None:

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -53,7 +53,7 @@ class TestReadNumber(unittest.TestCase):
                 value = self.read_number('Enter number: ')
                 output = fake_out.getvalue()
         self.assertEqual(value, 5.0)
-        self.assertIn('Please enter a valid number.', output)
+        self.assertIn("That doesn't look like a number. Did your cat walk on the keyboard?", output)
 
 
 class TestMainFlow(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Add cat-inspired error message when non-numeric input is provided
- Update tests to expect new message

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7e5385d88832ea41d65706c06f67d